### PR TITLE
Use amplify environment variables

### DIFF
--- a/frontend/amplify.yml
+++ b/frontend/amplify.yml
@@ -1,0 +1,20 @@
+version: 1
+applications:
+  - frontend:
+      phases:
+        preBuild:
+          commands:
+            - nvm use 12.21.0
+            - npm install
+        build:
+          commands:
+            - REACT_APP_CONTRACT=${REACT_APP_CONTRACT}
+            - npm run build
+      artifacts:
+        baseDirectory: build
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*
+    appRoot: frontend

--- a/frontend/amplify.yml
+++ b/frontend/amplify.yml
@@ -9,6 +9,7 @@ applications:
         build:
           commands:
             - REACT_APP_CONTRACT=${REACT_APP_CONTRACT}
+            - REACT_APP_NEAR_ENV=${REACT_APP_NEAR_ENV}
             - npm run build
       artifacts:
         baseDirectory: build

--- a/frontend/src/utils/near_interaction.js
+++ b/frontend/src/utils/near_interaction.js
@@ -9,7 +9,7 @@ import {
 export const storage_byte_cost = 10000000000000000000;
 //export const contract_name = "nativo.near";
 //export const contract_name = "dokxo.testnet";
-export const contract_name = "sub.nativoapp.testnet";
+export const contract_name = process.env.REACT_APP_CONTRACT;
 console.log(process.env.REACT_APP_CONTRACT)
 
 export const config = {

--- a/frontend/src/utils/near_interaction.js
+++ b/frontend/src/utils/near_interaction.js
@@ -10,6 +10,7 @@ export const storage_byte_cost = 10000000000000000000;
 //export const contract_name = "nativo.near";
 //export const contract_name = "dokxo.testnet";
 export const contract_name = "sub.nativoapp.testnet";
+console.log(process.env.REACT_APP_CONTRACT)
 
 export const config = {
   testnet: {

--- a/frontend/src/utils/near_interaction.js
+++ b/frontend/src/utils/near_interaction.js
@@ -89,6 +89,7 @@ export async function nearSignIn(URL) {
 
 export async function isNearReady() {
   // conectarse a near
+  let near
   (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
   //const near = await connect(config.testnet);
 
@@ -103,6 +104,7 @@ export async function isNearReady() {
  */
 export async function getNearContract() {
   // conectarse a near
+  let near
   (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
   //const near = await connect(config.testnet);
 
@@ -138,6 +140,7 @@ export function fromYoctoToNear(yocto) {
  * */
 export async function getNearAccount() {
   // conectarse a near
+  let near
   (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
   //const near = await connect(config.testnet);
 
@@ -149,6 +152,7 @@ export async function getNearAccount() {
 
 export async function signOut() {
   // conectarse a near
+  let near
   (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
   //const near = await connect(config.testnet);
 

--- a/frontend/src/utils/near_interaction.js
+++ b/frontend/src/utils/near_interaction.js
@@ -11,6 +11,7 @@ export const storage_byte_cost = 10000000000000000000;
 //export const contract_name = "dokxo.testnet";
 export const contract_name = process.env.REACT_APP_CONTRACT;
 console.log(process.env.REACT_APP_CONTRACT)
+console.log(process.env.REACT_APP_NEAR_ENV)
 
 export const config = {
   testnet: {

--- a/frontend/src/utils/near_interaction.js
+++ b/frontend/src/utils/near_interaction.js
@@ -77,7 +77,8 @@ export const methodOptions = {
  *hacemos el signIn con near
  */
 export async function nearSignIn(URL) {
-  window.near = await connect(config.testnet);
+  (process.env.REACT_APP_NEAR_ENV == "testnet" ? window.near = await connect(config.testnet) : window.near = await connect(config.mainnet))
+  //window.near = await connect(config.testnet);
   window.wallet = new WalletConnection(window.near, "latina");
 
   window.wallet.requestSignIn(
@@ -90,7 +91,8 @@ export async function nearSignIn(URL) {
 
 export async function isNearReady() {
   // conectarse a near
-  const near = await connect(config.testnet);
+  (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
+  //const near = await connect(config.testnet);
 
   // crear una wallet
   const wallet = new WalletConnection(near);
@@ -103,7 +105,8 @@ export async function isNearReady() {
  */
 export async function getNearContract() {
   // conectarse a near
-  const near = await connect(config.testnet);
+  (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
+  //const near = await connect(config.testnet);
 
   // crear una wallet de
   const wallet = new WalletConnection(near);
@@ -137,7 +140,8 @@ export function fromYoctoToNear(yocto) {
  * */
 export async function getNearAccount() {
   // conectarse a near
-  const near = await connect(config.testnet);
+  (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
+  //const near = await connect(config.testnet);
 
   // crear una wallet de
   const wallet = new WalletConnection(near);
@@ -147,7 +151,8 @@ export async function getNearAccount() {
 
 export async function signOut() {
   // conectarse a near
-  const near = await connect(config.testnet);
+  (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
+  //const near = await connect(config.testnet);
 
   // crear una wallet de
   const wallet = new WalletConnection(near);

--- a/frontend/src/utils/near_interaction.js
+++ b/frontend/src/utils/near_interaction.js
@@ -9,7 +9,7 @@ import {
 export const storage_byte_cost = 10000000000000000000;
 //export const contract_name = "nativo.near";
 //export const contract_name = "dokxo.testnet";
-export const contract_name = process.env.REACT_APP_CONTRACT;
+export const contract_name = "sub."+process.env.REACT_APP_CONTRACT;
 
 export const config = {
   testnet: {

--- a/frontend/src/utils/near_interaction.js
+++ b/frontend/src/utils/near_interaction.js
@@ -10,8 +10,6 @@ export const storage_byte_cost = 10000000000000000000;
 //export const contract_name = "nativo.near";
 //export const contract_name = "dokxo.testnet";
 export const contract_name = process.env.REACT_APP_CONTRACT;
-console.log(process.env.REACT_APP_CONTRACT)
-console.log(process.env.REACT_APP_NEAR_ENV)
 
 export const config = {
   testnet: {

--- a/frontend/src/utils/near_interaction.js
+++ b/frontend/src/utils/near_interaction.js
@@ -89,8 +89,7 @@ export async function nearSignIn(URL) {
 
 export async function isNearReady() {
   // conectarse a near
-  let near
-  (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
+  const near = (process.env.REACT_APP_NEAR_ENV == "testnet" ? await connect(config.testnet) : await connect(config.mainnet))
   //const near = await connect(config.testnet);
 
   // crear una wallet
@@ -104,8 +103,7 @@ export async function isNearReady() {
  */
 export async function getNearContract() {
   // conectarse a near
-  let near
-  (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
+  const near = (process.env.REACT_APP_NEAR_ENV == "testnet" ? await connect(config.testnet) : await connect(config.mainnet))
   //const near = await connect(config.testnet);
 
   // crear una wallet de
@@ -140,8 +138,7 @@ export function fromYoctoToNear(yocto) {
  * */
 export async function getNearAccount() {
   // conectarse a near
-  let near
-  (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
+  const near = (process.env.REACT_APP_NEAR_ENV == "testnet" ? await connect(config.testnet) : await connect(config.mainnet))
   //const near = await connect(config.testnet);
 
   // crear una wallet de
@@ -152,8 +149,7 @@ export async function getNearAccount() {
 
 export async function signOut() {
   // conectarse a near
-  let near
-  (process.env.REACT_APP_NEAR_ENV == "testnet" ? near = await connect(config.testnet) : near = await connect(config.mainnet))
+  const near = (process.env.REACT_APP_NEAR_ENV == "testnet" ? await connect(config.testnet) : await connect(config.mainnet))
   //const near = await connect(config.testnet);
 
   // crear una wallet de


### PR DESCRIPTION
The amplify configuration file was implemented, in this file the different environment variables that were defined in the amplify console were added to be able to use them within the frontend in react (REACT_APP_CONTRACT and REACT_APP_NEAR_ENV).
REACT_APP_CONTRACT - contract address
REACT_APP_NEAR_ENV - Know if found on mainnet or testnet


The near interaction file was modified to be able to consume the environment variables described above with their corresponding configuration to point to mainnet or testnet.

Everything is working correctly at the moment